### PR TITLE
org.bukkit.Effect.HAPPY_VILLAGER deprecated

### DIFF
--- a/src/com/jcdesimp/landlord/commands/Claim.java
+++ b/src/com/jcdesimp/landlord/commands/Claim.java
@@ -4,7 +4,7 @@ import com.jcdesimp.landlord.Landlord;
 import com.jcdesimp.landlord.persistantData.OwnedLand;
 import org.bukkit.ChatColor;
 import org.bukkit.Chunk;
-import org.bukkit.Effect;
+import org.bukkit.Particle;
 import org.bukkit.Sound;
 import org.bukkit.command.CommandSender;
 import org.bukkit.configuration.file.FileConfiguration;
@@ -142,7 +142,7 @@ public class Claim implements LandlordCommand {
                 }
             }
             Landlord.getInstance().getDatabase().save(land);
-            land.highlightLand(player, Effect.HAPPY_VILLAGER);
+            land.highlightLand(player, Particle.HAPPY_VILLAGER);
             sender.sendMessage(
                     ChatColor.GREEN + success
                             .replace("#{chunkCoords}", "(" + currChunk.getX() + ", " + currChunk.getZ() + ")")


### PR DESCRIPTION
HAPPY_VILLAGER was moved to org.bukkit.Particle .  Currently, using this with 1.11 throws an "internal error" but it's because the enum isn't found in Effect anymore.